### PR TITLE
Remove extra copyright statement

### DIFF
--- a/src/flowmm/rfm/vmap.py
+++ b/src/flowmm/rfm/vmap.py
@@ -1,6 +1,4 @@
 """Copyright (c) Meta Platforms, Inc. and affiliates."""
-
-"""Copyright (c) Meta Platforms, Inc. and affiliates."""
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
This statement and space caused an import error.

```
File "flowmm/src/flowmm/rfm/vmap.py", line 4                                                       
    from __future__ import annotations                                                                                     
    ^                                                                                                                      
SyntaxError: from __future__ imports must occur at the beginning of the file
```